### PR TITLE
fix savemat

### DIFF
--- a/manifest.ijs
+++ b/manifest.ijs
@@ -6,7 +6,7 @@ DESCRIPTION=: 0 : 0
 Viewmat displays tables of data graphically.
 )
 
-VERSION=: '1.0.90'
+VERSION=: '1.0.91'
 
 RELEASE=: 'j805'
 

--- a/source/methods.ijs
+++ b/source/methods.ijs
@@ -43,8 +43,8 @@ fms=. hforms''
 if. 0=#fms
 do. sminfo 'viewmat';'No viewmat forms.' return.
 end.
-wd 'psel ',(<0 1) pick fms
-(getbitmap'') writepng fl
+loc=. (<0 2) { fms
+(setalpha no_gui_bitmap__loc '') writepng fl
 )
 
 NB. =========================================================

--- a/source/util.ijs
+++ b/source/util.ijs
@@ -156,7 +156,9 @@ NB.
 NB. returns viewmat forms, in order of recent activity
 hforms=: 3 : 0
 fms=. <;._2 &> <;._2 wdqpx''
+if. 0=#fms do. empty '' return. end.
 fms=. fms #~ (2{"1 fms) e. VMH
+if. 0=#fms do. empty '' return. end.
 fms \: 0 ". &> 4{"1 fms
 )
 

--- a/viewmat.ijs
+++ b/viewmat.ijs
@@ -153,7 +153,9 @@ hcascade=: 3 : 0
 )
 hforms=: 3 : 0
 fms=. <;._2 &> <;._2 wdqpx''
+if. 0=#fms do. empty '' return. end.
 fms=. fms #~ (2{"1 fms) e. VMH
+if. 0=#fms do. empty '' return. end.
 fms \: 0 ". &> 4{"1 fms
 )
 hremove=: 3 : 0
@@ -331,8 +333,8 @@ fms=. hforms''
 if. 0=#fms
 do. sminfo 'viewmat';'No viewmat forms.' return.
 end.
-wd 'psel ',(<0 1) pick fms
-(getbitmap'') writepng fl
+loc=. (<0 2) { fms
+(setalpha no_gui_bitmap__loc '') writepng fl
 )
 setsize=: 3 : 0
 fms=. hforms''


### PR DESCRIPTION
1. In JQt, savemat_jviewmat_ draws the png directly. This fixes the following bug. Now savemat_jviewmat_ saves the image in a similar way as jconsole saves the image when viewmat is called.

NB. Run in Edit window.
load 'viewmat'
viewmat i. 3 3
savemat_jviewmat_ ''
NB. Created ~temp/viewmat.png file is empty (white).

2. In JQt, instead of the below error, a dialog window "No viewmat forms" appears.

   load 'viewmat' savemat_jviewmat_ '' |index error in hforms, executing dyad {"1 _
|   fms=.fms#~(2    {"1 fms)e.VMH
Press ENTER to inspect