### PR TITLE
fix readmat and ctrl-s

### DIFF
--- a/manifest.ijs
+++ b/manifest.ijs
@@ -6,7 +6,7 @@ DESCRIPTION=: 0 : 0
 Viewmat displays tables of data graphically.
 )
 
-VERSION=: '1.0.91'
+VERSION=: '1.0.92'
 
 RELEASE=: 'j805'
 

--- a/source/event.ijs
+++ b/source/event.ijs
@@ -6,7 +6,6 @@ viewmat_jctrl_fkey=: 3 : 'lab_jlab_ 0'
 NB. save png
 viewmat_sctrl_fkey=: 3 : 0
 fl=. jpath '~temp/',TITLE,'.png'
-wd 'psel viewmat'
 (getbitmap'') writepng fl
 )
 

--- a/source/methods.ijs
+++ b/source/methods.ijs
@@ -3,8 +3,12 @@ NB. viewmat methods
 NB. =========================================================
 NB.*closeall v close all viewmat windows
 closeall=: 3 : 0
-for_loc. setvmh VMH do.
-  viewmat_close__loc''
+for_fm. hforms'' do.
+  id=. > 1 { fm
+  loc=. 2 { fm
+  hremove__loc''
+  wd 'psel ',id,';pclose'
+  destroy__loc''
 end.
 )
 

--- a/source/methods.ijs
+++ b/source/methods.ijs
@@ -28,8 +28,8 @@ fms=. hforms''
 if. 0=#fms do.
   sminfo 'viewmat';'No viewmat forms.' return.
 end.
-wd 'psel ',(<0 1) pick fms
-getbitmap''
+loc=. (<0 2) { fms
+setalpha no_gui_bitmap__loc ''
 )
 
 NB. =========================================================

--- a/source/testfld.ijs
+++ b/source/testfld.ijs
@@ -1,6 +1,28 @@
-NB. test viewmat field view
+NB. Run in Edit window.
+load 'trig viewmat png'
 
-require 'trig graphics/viewmat'
+count_unique=: #@~.@,
+
+NB. =========================================================
+NB. Basic test suite
+BTS=: 3 : 0
+closeall_jviewmat_ ''
+assert. EMPTY -: hforms_jviewmat_ ''
+viewmat (i. 2 2) ; 'A'
+viewmat (i. 3 3) ; 'B'
+setsize_jviewmat_ 500 500
+assert. 500 500 -: getsize_jviewmat_ ''
+assert. 9 -: count_unique readmat_jviewmat_ ''
+assert. 2 -: # hforms_jviewmat_ ''
+closeall_jviewmat_ ''
+assert. EMPTY -: hforms_jviewmat_ ''
+viewmat i. 4 4
+savemat_jviewmat_ ''
+mat=: readpng jpath '~temp/viewmat.png'
+assert. mat -: readmat_jviewmat_ ''
+closeall_jviewmat_ ''
+assert. EMPTY -: hforms_jviewmat_ ''
+)
 
 NB.*jjota v complex i.
 NB.   jjota 3 4
@@ -34,8 +56,7 @@ jjota 3 4
 viewmat |. jjota 3 4
 jiota 2 2
 viewmat |. jiota 20 20
-
-viewmat |. lvp_jviewmat _0j7 + 2j0.125 *&.+. jjota 40 40
 )
 
+BTS ''
 0!:100 OTS

--- a/viewmat.ijs
+++ b/viewmat.ijs
@@ -303,8 +303,12 @@ end.
 
 )
 closeall=: 3 : 0
-for_loc. setvmh VMH do.
-  viewmat_close__loc''
+for_fm. hforms'' do.
+  id=. > 1 { fm
+  loc=. 2 { fm
+  hremove__loc''
+  wd 'psel ',id,';pclose'
+  destroy__loc''
 end.
 )
 getsize=: 3 : 0

--- a/viewmat.ijs
+++ b/viewmat.ijs
@@ -191,7 +191,6 @@ glpixels (0 0, mwh), mat (27 b.) 16bffffff
 viewmat_jctrl_fkey=: 3 : 'lab_jlab_ 0'
 viewmat_sctrl_fkey=: 3 : 0
 fl=. jpath '~temp/',TITLE,'.png'
-wd 'psel viewmat'
 (getbitmap'') writepng fl
 )
 viewmat_g_resize=: 3 : 0
@@ -321,8 +320,8 @@ fms=. hforms''
 if. 0=#fms do.
   sminfo 'viewmat';'No viewmat forms.' return.
 end.
-wd 'psel ',(<0 1) pick fms
-getbitmap''
+loc=. (<0 2) { fms
+setalpha no_gui_bitmap__loc ''
 )
 savemat=: 3 : 0
 fl=. y


### PR DESCRIPTION
1. readmat_jviewmat_ has been changed in a similar way to savemat_jviewmat_ from the previous commit. It fixes the following bug.

NB. Run in Edit window.
load 'viewmat'
viewmat i. 4 4
# ~. , readmat_jviewmat_ ''
NB. Returned 1. Expected 16.

2. Saving image by pressing Ctrl-S - line wd 'psel viewmat' in viewmat_sctrl_fkey caused the wrong image to save when for example there were multiple viewmat windows with the default viewmat title. Now the viewmat window that is currently in focus is saved.